### PR TITLE
feat(yggc): 支持 Yggdrasil Connect OAuth 授权

### DIFF
--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
@@ -304,7 +304,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
         JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
                 .addHeader("Authorization", "Bearer " + accessToken)
-                .build(), true);
+                .build());
         Profile profile = readProfiles(userinfo).getFirst();
 
         JsonObject OAuth = new JsonObject();
@@ -335,7 +335,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
                 "grant_type", "refresh_token",
                 "refresh_token", refreshToken
         );
-        JsonObject token = NetworkUtils.postRequest(tokenEndpoint, form, true);
+        JsonObject token = NetworkUtils.postRequest(tokenEndpoint, form);
 
         JsonElement err = token.get("error");
         if (err !=null) throw new IOException("Unknown error: " + err.getAsString());
@@ -345,7 +345,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
         JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
                 .addHeader("Authorization", "Bearer " + accessToken)
-                .build(), true);
+                .build());
         Profile profile = readProfiles(userinfo).getFirst();
         account.setProfile(accessToken, profile.playerName, AccountUUID.parse(profile.playerUUID));
         account.setLoginProfile("OAuth " + OAuth, profile.playerUUID);

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
@@ -305,7 +305,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
         JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
                 .addHeader("Authorization", "Bearer " + accessToken)
                 .build());
-        Profile profile = readProfiles(userinfo).getFirst();
+        Profile profile = readProfiles(userinfo).get(0);
 
         JsonObject OAuth = new JsonObject();
         OAuth.addProperty("token_endpoint", tokenEndpoint);
@@ -346,7 +346,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
         JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
                 .addHeader("Authorization", "Bearer " + accessToken)
                 .build());
-        Profile profile = readProfiles(userinfo).getFirst();
+        Profile profile = readProfiles(userinfo).get(0);
         account.setProfile(accessToken, profile.playerName, AccountUUID.parse(profile.playerUUID));
         account.setLoginProfile("OAuth " + OAuth, profile.playerUUID);
     }

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
@@ -266,9 +266,10 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
         if (device.get("interval") instanceof JsonPrimitive jp &&
                 jp.isNumber()) interval = jp.getAsInt();
         else interval = 5;
-        if (device.get("verification_uri_complete") instanceof JsonPrimitive jp &&
-                jp.isString()) Adapters.getMinecraftAdapter().openBrowser(jp.getAsString());
-        else {
+        if (device.get("verification_uri_complete") instanceof JsonPrimitive jp && jp.isString()) {
+            Adapters.getMinecraftAdapter().openBrowser(jp.getAsString());
+            Adapters.getMinecraftAdapter().copyText(jp.getAsString());
+        } else {
             Adapters.getMinecraftAdapter().copyText(userCode);
             device.get("verification_uri").getAsString();
         }

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/AbstractInjectorAccountProvider.java
@@ -1,17 +1,16 @@
 package net.burningtnt.accountsx.core.accounts.impl.injector;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.*;
 import net.burningtnt.accountsx.core.accounts.AccountProvider;
 import net.burningtnt.accountsx.core.accounts.AccountUUID;
 import net.burningtnt.accountsx.core.accounts.model.PlayerNoLongerExistedException;
 import net.burningtnt.accountsx.core.accounts.model.context.*;
+import net.burningtnt.accountsx.core.adapters.Adapters;
 import net.burningtnt.accountsx.core.ui.Memory;
 import net.burningtnt.accountsx.core.ui.UIScreen;
 import net.burningtnt.accountsx.core.utils.NetworkUtils;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.RequestBuilder;
 
 import java.io.IOException;
 import java.security.KeyFactory;
@@ -19,10 +18,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public abstract class AbstractInjectorAccountProvider<T extends AbstractInjectorAccount> implements AccountProvider<T> {
     private static final String GUID_SERVER_BASE = "guid:as.login.injector.widgets.server_url";
@@ -32,11 +28,14 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
     private final String serverBaseTranslationKey;
 
+    private final String userBaseTranslationKey;
+
     private final String accountContextName;
 
-    protected AbstractInjectorAccountProvider(String serverBaseTranslationKey, String accountContextName) {
+    protected AbstractInjectorAccountProvider(String serverBaseTranslationKey, String userBaseTranslationKey, String accountContextName) {
         this.serverBaseTranslationKey = serverBaseTranslationKey;
         this.accountContextName = accountContextName;
+        this.userBaseTranslationKey = userBaseTranslationKey;
     }
 
     protected void validateServerBaseURL(String server) throws IllegalArgumentException {
@@ -103,7 +102,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
     public final void configure(UIScreen screen) {
         screen.setTitle("as.account.general.login");
         screen.putTextInput(GUID_SERVER_BASE, serverBaseTranslationKey);
-        screen.putTextInput(GUID_USER_NAME, "as.account.objects.user_name");
+        screen.putTextInput(GUID_USER_NAME, userBaseTranslationKey);
         screen.putTextInput(GUID_PASSWORD, "as.account.objects.user_password");
         screen.putTextInput(GUID_PLAYER_NAME, "as.account.objects.player_name");
     }
@@ -122,6 +121,7 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
     @Override
     public final T login(Memory memory) throws IOException {
+        if (memory.get(GUID_USER_NAME, String.class).isEmpty()) return loginOAuth(memory.get(GUID_SERVER_BASE, String.class));
         String url = transformServerBaseURL(memory.get(GUID_SERVER_BASE, String.class)) + "authserver/authenticate";
 
         JsonObject agent = new JsonObject();
@@ -171,6 +171,10 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
     @Override
     public final void refresh(T account) throws IOException {
+        if (account.getLoginToken().startsWith("OAuth ")) {
+            refreshOAuth(account);
+            return;
+        }
         String url = transformServerBaseURL(account.getServer()) + "authserver/refresh";
 
         JsonObject root = new JsonObject();
@@ -227,5 +231,123 @@ public abstract class AbstractInjectorAccountProvider<T extends AbstractInjector
 
             return results;
         }
+    }
+
+    private T loginOAuth(String host) throws IOException {
+        String yggUrl = transformServerBaseURL(host);
+
+        String openidConfigurationUrl;
+        JsonObject ygg = NetworkUtils.postRequest(new HttpGet(yggUrl));
+        if (ygg.get("meta") instanceof JsonObject meta &&
+                meta.get("feature.openid_configuration_url") instanceof JsonPrimitive jp1 &&
+                jp1.isString()) openidConfigurationUrl = jp1.getAsString();
+        else throw new IOException("Invalid openid configuration url!");
+
+        JsonObject config = NetworkUtils.postRequest(new HttpGet(openidConfigurationUrl));
+        String deviceAuthorizationEndpoint = config.get("device_authorization_endpoint").getAsString();
+        String tokenEndpoint = config.get("token_endpoint").getAsString();
+        String userInfoEndpoint = config.get("userinfo_endpoint").getAsString();
+        String clientId;
+        if (OAuthConstants.list.containsKey(host)) clientId = OAuthConstants.list.get(host);
+        else if (config.get("shared_client_id") instanceof JsonPrimitive jp2 &&
+                jp2.isString()) clientId = jp2.getAsString();
+        else throw new IOException("Invalid client id!");
+
+        Adapters.getMinecraftAdapter().showToast("as.account.oauth2.code.generating", null);
+
+        Map<String, String> form1 = Map.of(
+                "client_id", clientId,
+                "scope", "openid offline_access Yggdrasil.PlayerProfiles.Select Yggdrasil.Server.Join"
+        );
+        JsonObject device = NetworkUtils.postRequest(deviceAuthorizationEndpoint, form1);
+        String deviceCode = device.get("device_code").getAsString();
+        String userCode = device.get("user_code").getAsString();
+        int interval;
+        if (device.get("interval") instanceof JsonPrimitive jp &&
+                jp.isNumber()) interval = jp.getAsInt();
+        else interval = 5;
+        if (device.get("verification_uri_complete") instanceof JsonPrimitive jp &&
+                jp.isString()) Adapters.getMinecraftAdapter().openBrowser(jp.getAsString());
+        else {
+            Adapters.getMinecraftAdapter().copyText(userCode);
+            device.get("verification_uri").getAsString();
+        }
+        Adapters.getMinecraftAdapter().showToast("as.account.oauth2.code.title", "as.account.oauth2.code.desc", userCode);
+
+        String accessToken, refreshToken;
+        while(true) {
+            try {
+                Thread.sleep(Math.max(interval, 1));
+            } catch (InterruptedException e) {
+                throw new IOException("Interrupted.", e);
+            }
+
+            Map<String, String> form2 = Map.of(
+                    "client_id", clientId,
+                    "grant_type", "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code", deviceCode
+            );
+            JsonObject token = NetworkUtils.postRequest(tokenEndpoint, form2, true);
+
+            JsonElement err = token.get("error");
+            if (err == null) {
+                accessToken = token.get("access_token").getAsString();
+                refreshToken = token.get("refresh_token").getAsString();
+                break;
+            }
+
+            String error = err.getAsString();
+            if (error.equals("authorization_pending")) continue;
+            if (error.equals("expired_token")) throw new IOException("No character detected.");
+            throw new IOException("Unknown error: " + error);
+        }
+
+        JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
+                .addHeader("Authorization", "Bearer " + accessToken)
+                .build(), true);
+        Profile profile = readProfiles(userinfo).getFirst();
+
+        JsonObject OAuth = new JsonObject();
+        OAuth.addProperty("token_endpoint", tokenEndpoint);
+        OAuth.addProperty("refresh_token", refreshToken);
+        OAuth.addProperty("client_id", clientId);
+        OAuth.addProperty("userinfo_endpoint", userInfoEndpoint);
+
+        T account = createAccount(
+                accessToken, profile.playerName, AccountUUID.parse(profile.playerUUID),
+                host, profile.playerUUID
+        );
+        account.setLoginProfile("OAuth " + OAuth, profile.playerUUID);
+        return account;
+    }
+
+    private void refreshOAuth(T account) throws IOException {
+        String OAuthStr = account.getLoginToken().substring(6);
+        JsonObject OAuth = JsonParser.parseString(OAuthStr).getAsJsonObject();
+
+        String tokenEndpoint = OAuth.get("token_endpoint").getAsString();
+        String refreshToken = OAuth.get("refresh_token").getAsString();
+        String clientId = OAuth.get("client_id").getAsString();
+        String userInfoEndpoint = OAuth.get("userinfo_endpoint").getAsString();
+
+        Map<String, String> form = Map.of(
+                "client_id", clientId,
+                "grant_type", "refresh_token",
+                "refresh_token", refreshToken
+        );
+        JsonObject token = NetworkUtils.postRequest(tokenEndpoint, form, true);
+
+        JsonElement err = token.get("error");
+        if (err !=null) throw new IOException("Unknown error: " + err.getAsString());
+        String accessToken = token.get("access_token").getAsString();
+        refreshToken = token.get("refresh_token").getAsString();
+        OAuth.addProperty("refresh_token", refreshToken);
+
+        JsonObject userinfo = NetworkUtils.postRequest(RequestBuilder.get(userInfoEndpoint)
+                .addHeader("Authorization", "Bearer " + accessToken)
+                .build(), true);
+        Profile profile = readProfiles(userinfo).getFirst();
+        account.setProfile(accessToken, profile.playerName, AccountUUID.parse(profile.playerUUID));
+        account.setLoginProfile("OAuth " + OAuth, profile.playerUUID);
     }
 }

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/OAuthConstants.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/OAuthConstants.java
@@ -1,0 +1,11 @@
+package net.burningtnt.accountsx.core.accounts.impl.injector;
+
+import java.util.Map;
+
+public class OAuthConstants {
+    public static final Map<String, String> list = Map.of(
+            "skin.jsumc.fun", "3",
+            "skin.mualliance.ltd", "28",
+            "littleskin.cn", "1214"
+    );
+}

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/impl/AuthlibInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/impl/AuthlibInjectorAccountProvider.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public final class AuthlibInjectorAccountProvider extends AbstractInjectorAccountProvider<AuthlibInjectorAccountProvider.AuthlibInjectorAccount> {
     public AuthlibInjectorAccountProvider() {
-        super("as.account.objects.server_domain", "Authlib-Injector");
+        super("as.account.objects.server_domain", "as.account.objects.user_id", "Authlib-Injector");
     }
 
     @Override

--- a/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/impl/UnitedInjectorAccountProvider.java
+++ b/src/main/java/net/burningtnt/accountsx/core/accounts/impl/injector/impl/UnitedInjectorAccountProvider.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public final class UnitedInjectorAccountProvider extends AbstractInjectorAccountProvider<UnitedInjectorAccountProvider.UnitedInjectorAccount> {
     public UnitedInjectorAccountProvider() {
-        super("as.account.objects.server_id", "United-Injector");
+        super("as.account.objects.server_id", "as.account.objects.user_name", "United-Injector");
     }
 
     private static final BitSet SAFE_SERVER_ID = new BitSet(128);

--- a/src/main/java/net/burningtnt/accountsx/core/utils/NetworkUtils.java
+++ b/src/main/java/net/burningtnt/accountsx/core/utils/NetworkUtils.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.UUID;
 
 public class NetworkUtils {
@@ -26,7 +27,7 @@ public class NetworkUtils {
             .setPrettyPrinting()
             .create();
 
-    private static final HttpClientBuilder BUILDER = HttpClientBuilder.create().setRedirectStrategy(new DefaultRedirectStrategy());;
+    private static final HttpClientBuilder BUILDER = HttpClientBuilder.create().setRedirectStrategy(new DefaultRedirectStrategy());
 
     public static JsonObject postRequest(HttpUriRequest request) throws IOException {
         return postRequest(request, false);
@@ -45,6 +46,18 @@ public class NetworkUtils {
                 .addHeader("Content-Type", "application/json")
                 .setEntity(new StringEntity(NetworkUtils.GSON.toJson(json)))
                 .build());
+    }
+
+    public static JsonObject postRequest(String url, Map<String, String> formData, boolean ignoreHttpStatus) throws IOException {
+        RequestBuilder requestBuilder = RequestBuilder.post(url)
+                .addHeader("Content-Type", "application/x-www-form-urlencoded");
+        for (java.util.Map.Entry<String, String> entry : formData.entrySet())
+            requestBuilder.addParameter(entry.getKey(), entry.getValue());
+        return postRequest(requestBuilder.build(), ignoreHttpStatus);
+    }
+
+    public static JsonObject postRequest(String url, Map<String, String> formData) throws IOException {
+        return postRequest(url, formData, false);
     }
 
     public static Reader readResponse(HttpResponse response, boolean ignoreHttpStatus) throws IOException {

--- a/src/main/resources/assets/accountsx/lang/en_us.json
+++ b/src/main/resources/assets/accountsx/lang/en_us.json
@@ -14,6 +14,7 @@
   "as.account.objects.player_uuid": "Player UUID",
   "as.account.objects.server_domain": "Yggdrasil API URL (Root Domain Only)",
   "as.account.objects.server_id": "Server ID",
+  "as.account.objects.user_id": "User ID (Leave blank to use OAuth)",
   "as.account.objects.user_name": "User ID",
   "as.account.objects.user_password": "User Password",
   "as.account.state.authorized.name": "Available",

--- a/src/main/resources/assets/accountsx/lang/zh_cn.json
+++ b/src/main/resources/assets/accountsx/lang/zh_cn.json
@@ -14,6 +14,7 @@
   "as.account.objects.player_uuid": "玩家 UUID",
   "as.account.objects.server_domain": "认证服务器（仅根域名）",
   "as.account.objects.server_id": "服务器 ID",
+  "as.account.objects.user_id": "用户 ID（OAuth留空）",
   "as.account.objects.user_name": "用户 ID",
   "as.account.objects.user_password": "用户密码",
   "as.account.state.authorized.name": "正常可用",


### PR DESCRIPTION
目前的方案是留空用户ID自动使用 Yggdrasil Connect OAuth 授权，
刷新需要用的数据用json字符串存在loginToken里，加上"OAuth "前缀和账号密码登入做区分。